### PR TITLE
COMP: adding ITK_ prefix to testing macros

### DIFF
--- a/test/itkMinimalStandardRandomVariateGeneratorTest.cxx
+++ b/test/itkMinimalStandardRandomVariateGeneratorTest.cxx
@@ -26,11 +26,11 @@ int itkMinimalStandardRandomVariateGeneratorTest( int, char * [] )
   typedef itk::Statistics::MinimalStandardRandomVariateGenerator GeneratorType;
   GeneratorType::Pointer generator = GeneratorType::New();
   
-  EXERCISE_BASIC_OBJECT_METHODS( generator, MinimalStandardRandomVariateGenerator, RandomVariateGeneratorBase );
+  ITK_EXERCISE_BASIC_OBJECT_METHODS( generator, MinimalStandardRandomVariateGenerator, RandomVariateGeneratorBase );
 
   generator->Initialize( 324 );
 
-  TEST_EXPECT_TRUE( itk::Math::FloatAlmostEqual( generator->GetVariate(), 1.35581 , 4 , 0.0001));
+  ITK_TEST_EXPECT_TRUE( itk::Math::FloatAlmostEqual( generator->GetVariate(), 1.35581 , 4 , 0.0001));
 
   return EXIT_SUCCESS;
 }

--- a/test/itkMyFilterTest.cxx
+++ b/test/itkMyFilterTest.cxx
@@ -70,7 +70,7 @@ int itkMyFilterTest( int argc, char * argv[] )
   using FilterType = itk::MyFilter< ImageType, ImageType >;
   FilterType::Pointer filter = FilterType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS( filter, MyFilter, ImageToImageFilter );
+  ITK_EXERCISE_BASIC_OBJECT_METHODS( filter, MyFilter, ImageToImageFilter );
 
   // Create input image to avoid test dependencies.
   ImageType::SizeType size;
@@ -90,7 +90,7 @@ int itkMyFilterTest( int argc, char * argv[] )
   writer->SetInput( filter->GetOutput() );
   writer->SetUseCompression(true);
 
-  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+  ITK_TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
   std::cout << "Test finished." << std::endl;


### PR DESCRIPTION
This enables compiling without legacy code.